### PR TITLE
Create a workflow to add items to the project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,32 @@
+name: Add to project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: ${{ vars.PROJECT_URL }}
+          github-token: ${{ secrets.PROJECTS_PAT }}
+      - name: Set subteam
+        uses: EndBug/project-fields@a843f1eac1a2772a9d475cfd4bb32d68225c558c
+        with:
+          # The type of field operation. Valid options are "get", "set", "clear"
+          operation: set
+          # A comma-separated list of fields to get or update
+          fields: Subteam
+          # The GitHub token to use for authentication
+          github_token: ${{ secrets.PROJECTS_PAT }}
+          # The URL of the project
+          project_url: ${{ vars.PROJECT_URL }}
+          # A comma-separated list of values to update the fields with
+          values: Programming


### PR DESCRIPTION
This creates an Actions workflow that runs when an Issue or Pull Request is opened and adds it to the GitHub Project. Doing this with an action instead of using the built-in workflows in Projects allows for fields to be automatically populated, and this is used here to assign a value of Programming to the Subteam field.