### PR TITLE
Use a GitHub App to generate workflow tokens

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,11 +13,18 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - name: Generate an authentication token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BLAZER_BOT_APP_ID }}
+          private-key: ${{ secrets.BLAZER_BOT_PRIVATE_KEY }}
+      - name: Add item to project
+        uses: actions/add-to-project@v1.0.2
         with:
           project-url: ${{ vars.PROJECT_URL }}
-          github-token: ${{ secrets.PROJECTS_PAT }}
-      - name: Set subteam
+          github-token: ${{ steps.app-token.outputs.token }}
+      - name: Set item subteam
         uses: EndBug/project-fields@a843f1eac1a2772a9d475cfd4bb32d68225c558c
         with:
           # The type of field operation. Valid options are "get", "set", "clear"
@@ -25,7 +32,7 @@ jobs:
           # A comma-separated list of fields to get or update
           fields: Subteam
           # The GitHub token to use for authentication
-          github_token: ${{ secrets.PROJECTS_PAT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           # The URL of the project
           project_url: ${{ vars.PROJECT_URL }}
           # A comma-separated list of values to update the fields with


### PR DESCRIPTION
Use a GitHub App to generate authentication tokens for workflow runs instead of a personal access token.